### PR TITLE
#4 Remove xsbt-filter plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git"     % "0.9.3")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"     % "1.0.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site"    % "1.2.1")
-addSbtPlugin("com.github.sdb"   % "xsbt-filter" % "0.4")
 
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25" // Needed by sbt-git
 


### PR DESCRIPTION
This should clear to way for upgrading to sbt 1.0.
The solution is rather nasty but as it seems there is no other way apart from writing an own sbt-plugin for this.

### Changes

* remove xsbt-filter plugin
* write `resourceGenerators` task in `build.sbt`
* fixes #4 
